### PR TITLE
EVG-7075: implement nolint directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 evg-lint is a linter for common problems encountered in the 
 [Evergreen](https://github.com/evergreen-ci/evergreen) codebase 
 
-[![Build Status](https://travis-ci.org/richardsamuels/evg-lint.svg?branch=master)](https://travis-ci.org/richardsamuels/evg-lint)
-
 ## Installation
 
 Golint requires Go 1.6 or later.
 
-    go get -u github.com/richardsamuels/evg-lint/evg-lint
+    go get -u github.com/evergreen-ci/evg-lint/evg-lint
 
 ## Usage
 

--- a/evg-lint/evg-lint.go
+++ b/evg-lint/evg-lint.go
@@ -16,7 +16,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/richardsamuels/evg-lint"
+	"github.com/evergreen-ci/evg-lint"
 )
 
 var (

--- a/lint.go
+++ b/lint.go
@@ -22,7 +22,6 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/k0kubun/pp"
 	"golang.org/x/tools/go/gcexportdata"
 )
 
@@ -88,7 +87,6 @@ func (l *Linter) LintFiles(files map[string][]byte) ([]Problem, error) {
 	}
 	var pkgName string
 	for filename, src := range files {
-		pp.Println("linting file", filename)
 		if isGenerated(src) {
 			continue // See issue #239
 		}
@@ -101,7 +99,6 @@ func (l *Linter) LintFiles(files map[string][]byte) ([]Problem, error) {
 		} else if f.Name.Name != pkgName {
 			return nil, fmt.Errorf("%s is in package %s, not %s", filename, f.Name.Name, pkgName)
 		}
-		pp.Println("getting ignores for file:", filename)
 		pkg.files[filename] = &file{
 			pkg:      pkg,
 			f:        f,
@@ -722,10 +719,6 @@ type ignoredRange struct {
 
 func (i *ignoredRange) matches(line int, linter string) bool {
 	if line < i.start || line > i.end {
-		pp.Println("ignore outside of line range")
-		pp.Println("line = ", line)
-		pp.Println("ignore start =", i.start)
-		pp.Println("ignore end = ", i.end)
 		return false
 	}
 	if len(i.linters) == 0 {

--- a/lint.go
+++ b/lint.go
@@ -212,6 +212,17 @@ func (f *file) errorf(n ast.Node, confidence float64, args ...interface{}) *Prob
 	return f.pkg.errorfAt(pos, confidence, args...)
 }
 
+// isIgnored returns whether or not the node is to be ignored by a linter.
+func (f *file) isIgnored(node ast.Node) bool {
+	for _, ignore := range f.ignored {
+		position := f.fset.PositionFor(node.Pos(), false)
+		if ignore.matches(position.Line, "evg-lint") {
+			return true
+		}
+	}
+	return false
+}
+
 func (p *pkg) errorfAt(pos token.Position, confidence float64, args ...interface{}) *Problem {
 	problem := Problem{
 		Position:   pos,
@@ -763,7 +774,7 @@ func (a *rangeExpander) Visit(node ast.Node) ast.Visitor {
 }
 
 // near returns true if the given ignored range is immediately above the given
-// position.(i.e. at the same level of indentation and starts immediately after
+// position (i.e. at the same level of indentation and starts immediately after
 // the ignore).
 func (i *ignoredRange) near(col, start int) bool {
 	return col == i.col && i.end == start-1

--- a/linters.go
+++ b/linters.go
@@ -50,7 +50,6 @@ func implementsTestifySuite(obj *ast.Object) bool {
 	return false
 }
 
-// kim: implement nolint
 func (f *file) lintTestify() {
 	if !f.isTest() {
 		return
@@ -108,7 +107,6 @@ func (f *file) lintTestify() {
 	})
 }
 
-// kim: implement nolint
 // Lint the spelling of the word "canceled", ensuring it's spelled the AmE way
 func (f *file) lintCancelled() {
 	f.walk(func(node ast.Node) bool {
@@ -131,7 +129,6 @@ func (f *file) lintCancelled() {
 // isIgnored returns whether or not the node is to be ignored by a linter.
 func (f *file) isIgnored(node ast.Node) bool {
 	for _, ignore := range f.ignored {
-		// TODO: adjusted?
 		position := f.fset.PositionFor(node.Pos(), false)
 		if ignore.matches(position.Line, "evg-lint") {
 			return true
@@ -140,7 +137,6 @@ func (f *file) isIgnored(node ast.Node) bool {
 	return false
 }
 
-// kim: TODO: implement nolint
 func (f *file) lintForLoopDefer() {
 	f.walk(func(node ast.Node) bool {
 		switch v := node.(type) {

--- a/linters.go
+++ b/linters.go
@@ -126,17 +126,6 @@ func (f *file) lintCancelled() {
 	})
 }
 
-// isIgnored returns whether or not the node is to be ignored by a linter.
-func (f *file) isIgnored(node ast.Node) bool {
-	for _, ignore := range f.ignored {
-		position := f.fset.PositionFor(node.Pos(), false)
-		if ignore.matches(position.Line, "evg-lint") {
-			return true
-		}
-	}
-	return false
-}
-
 func (f *file) lintForLoopDefer() {
 	f.walk(func(node ast.Node) bool {
 		switch v := node.(type) {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-7075

We have to do this because golangci-lint doesn't support custom linter binaries, so evg-lint will have to be invoked from run-linter directly.

* Support same-lint nolint comments.
Example:
```
// Ignore the one line below
foo := "bar" // nolint: evg-lint
```
* Support block-level nolint comments.
Example:
```
// Ignore the entire foo function
// nolint: evg-lint
func foo() {
...
}
```
* Minor cleanup.